### PR TITLE
multi-sig segwit initialization bug

### DIFF
--- a/virtualchain/lib/blockchain/bitcoin_blockchain/multisig.py
+++ b/virtualchain/lib/blockchain/bitcoin_blockchain/multisig.py
@@ -196,7 +196,7 @@ def make_multisig_segwit_wallet( m, n ):
         pk = BitcoinPrivateKey(compressed=True).to_wif()
         pks.append(pk)
 
-    return make_multisig_segwit_info(m, [pks])
+    return make_multisig_segwit_info(m, pks)
 
 
 def parse_multisig_redeemscript( redeem_script_hex ):


### PR DESCRIPTION
Small bug, but it causes wallet initialization to fail for multi-sig segwit addresses, which are now _default_ for wallet setups as of `blockstack-core-0.17.0.11`. Meaning this affects _all_ users creating new wallets.